### PR TITLE
Add platform flag to Dockerfile base image load to support building t…

### DIFF
--- a/demo-service/Dockerfile
+++ b/demo-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM --platform=linux/amd64 node:16-alpine
 COPY . /srv/
 RUN cd /srv/ && \
     npm i --only=prod --no-audit


### PR DESCRIPTION
This commit modifies the Dockerfile to include the --platform=linux/amd64 flag when loading the base image. The base image itself has not been changed. This change ensures compatibility and enables local building of the Docker image on macOS using the specified platform by overwriting the default platform value.